### PR TITLE
Task validation fixes and rewrites (by Steampunk Spotter)

### DIFF
--- a/tasks/auditd.yml
+++ b/tasks/auditd.yml
@@ -20,7 +20,8 @@
       - Restart auditd
 
 - name: POST | AUDITD | Add Warning count for changes to template file | Warn Count  # noqa no-handler
-  ansible.builtin.import_tasks: warning_facts.yml
+  ansible.builtin.import_tasks:
+    file: warning_facts.yml
   vars:
       warn_control_id: 'Auditd template updated, see diff output for details'
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,7 +86,8 @@
       - always
 
 - name: Include preliminary steps
-  ansible.builtin.import_tasks: prelim.yml
+  ansible.builtin.import_tasks:
+    file: prelim.yml
   tags:
       - prelim_tasks
       - always
@@ -94,61 +95,70 @@
 - name: Run pre_remediation audit
   when:
       - run_audit
-  ansible.builtin.include_tasks: pre_remediation_audit.yml
+  ansible.builtin.include_tasks:
+    file: pre_remediation_audit.yml
   tags:
       - run_audit
 
 - name: Run Section 1 tasks
   when:
       - amzn2023cis_section1
-  ansible.builtin.import_tasks: section_1/main.yml
+  ansible.builtin.import_tasks:
+    file: section_1/main.yml
   tags:
       - amzn2023cis_section1
 
 - name: Run Section 2 tasks
   when:
       - amzn2023cis_section2
-  ansible.builtin.import_tasks: section_2/main.yml
+  ansible.builtin.import_tasks:
+    file: section_2/main.yml
   tags:
       - amzn2023cis_section2
 
 - name: Run Section 3 tasks
   when:
       - amzn2023cis_section3
-  ansible.builtin.import_tasks: section_3/main.yml
+  ansible.builtin.import_tasks:
+    file: section_3/main.yml
   tags:
       - amzn2023cis_section3
 
 - name: Run Section 4 tasks
   when:
       - amzn2023cis_section4
-  ansible.builtin.import_tasks: section_4/main.yml
+  ansible.builtin.import_tasks:
+    file: section_4/main.yml
   tags:
       - amzn2023cis_section4
 
 - name: Run Section 5 tasks
   when:
       - amzn2023cis_section5
-  ansible.builtin.import_tasks: section_5/main.yml
+  ansible.builtin.import_tasks:
+    file: section_5/main.yml
   tags:
       - amzn2023cis_section5
 
 - name: Run Section 6 tasks
   when:
       - amzn2023cis_section6
-  ansible.builtin.import_tasks: section_6/main.yml
+  ansible.builtin.import_tasks:
+    file: section_6/main.yml
   tags:
       - amzn2023cis_section6
 
 - name: run auditd logic
   when:
       - update_audit_template
-  ansible.builtin.import_tasks: auditd.yml
+  ansible.builtin.import_tasks:
+    file: auditd.yml
   tags:
       - always
 
 - name: run post remediation tasks
-  ansible.builtin.import_tasks: post.yml
+  ansible.builtin.import_tasks:
+    file: post.yml
   tags:
       - post_tasks
       - always
@@ -156,7 +166,8 @@
 - name: run post_remediation audit
   when:
       - run_audit
-  ansible.builtin.import_tasks: post_remediation_audit.yml
+  ansible.builtin.import_tasks:
+    file: post_remediation_audit.yml
 
 - name: Show Audit Summary
   when:

--- a/tasks/post.yml
+++ b/tasks/post.yml
@@ -46,7 +46,8 @@
             - skip_reboot
 
       - name: "POST | Warning a reboot required but skip option set | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when:
             - change_requires_reboot
             - skip_reboot

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -59,9 +59,8 @@
 
       - name: Pre Audit Setup | If audit ensure goss is available
         ansible.builtin.assert:
+            that: goss_available.stat.exists
             msg: "Audit has been selected: unable to find goss binary at {{ audit_bin }}"
-        when:
-            - not goss_available.stat.exists
   when:
       - run_audit
 

--- a/tasks/pre_remediation_audit.yml
+++ b/tasks/pre_remediation_audit.yml
@@ -1,7 +1,8 @@
 ---
 
 - name: Pre Audit Binary Setup | Setup the LE audit
-  ansible.builtin.include_tasks: LE_audit_setup.yml
+  ansible.builtin.include_tasks:
+    file: LE_audit_setup.yml
   when:
       - setup_audit
   tags:

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -12,7 +12,8 @@
       - users
 
 - name: "PRELIM | capture /etc/password variables"
-  ansible.builtin.include_tasks: parse_etc_password.yml
+  ansible.builtin.include_tasks:
+    file: parse_etc_password.yml
   tags:
       - rule_5.5.2
       - rule_5.6.2

--- a/tasks/section_1/cis_1.1.2.x.yml
+++ b/tasks/section_1/cis_1.1.2.x.yml
@@ -7,7 +7,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.2.1 | PATCH | Ensure /tmp is a separate partition | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
   vars:
       warn_control_id: '1.1.2.1'
       required_mount: '/tmp'

--- a/tasks/section_1/cis_1.1.3.x.yml
+++ b/tasks/section_1/cis_1.1.3.x.yml
@@ -7,7 +7,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.3.1 | AUDIT | Ensure separate partition exists for /var | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
   vars:
       warn_control_id: '1.1.3.1'
       required_mount: '/var'

--- a/tasks/section_1/cis_1.1.4.x.yml
+++ b/tasks/section_1/cis_1.1.4.x.yml
@@ -8,7 +8,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.4.1 | AUDIT | Ensure separate partition exists for /var/tmp | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
   vars:
       warn_control_id: '1.1.4.1'
       required_mount: '/var/tmp'

--- a/tasks/section_1/cis_1.1.5.x.yml
+++ b/tasks/section_1/cis_1.1.5.x.yml
@@ -7,7 +7,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.5.1 | AUDIT | Ensure separate partition exists for /var/log | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
 
   vars:
       warn_control_id: '1.1.5.1'

--- a/tasks/section_1/cis_1.1.6.x.yml
+++ b/tasks/section_1/cis_1.1.6.x.yml
@@ -7,7 +7,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.6.1 | AUDIT | Ensure separate partition exists for /var/log/audit | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
 
   vars:
       warn_control_id: '1.1.6.1'

--- a/tasks/section_1/cis_1.1.7.x.yml
+++ b/tasks/section_1/cis_1.1.7.x.yml
@@ -7,7 +7,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.7.1 | AUDIT | Ensure separate partition exists for /home | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
 
   vars:
       warn_control_id: '1.1.7.1'

--- a/tasks/section_1/cis_1.1.8.x.yml
+++ b/tasks/section_1/cis_1.1.8.x.yml
@@ -8,7 +8,8 @@
             msg: "Warning!! {{ required_mount }} doesn't exist. This is a manual task"
 
       - name: "1.1.8.1 | AUDIT | Ensure separate partition exists for /home | Present"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
 
   vars:
       warn_control_id: '1.1.8.1'

--- a/tasks/section_1/cis_1.2.x.yml
+++ b/tasks/section_1/cis_1.2.x.yml
@@ -71,7 +71,8 @@
                 - "{{ dnf_configured.stdout_lines }}"
 
       - name: "1.2.3 | AUDIT | Ensure package manager repositories are configured | Warn Count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
   vars:
       warn_control_id: '1.2.3'
   when:

--- a/tasks/section_1/cis_1.6.1.x.yml
+++ b/tasks/section_1/cis_1.6.1.x.yml
@@ -97,7 +97,8 @@
         when: amzn2023cis_1_6_1_6_unconf_services.stdout | length > 0
 
       - name: "1.6.1.6 | AUDIT | Ensure no unconfined services exist | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when: amzn2023cis_1_6_1_6_unconf_services.stdout | length > 0
   vars:
       warn_control_id: '1.6.1.6'

--- a/tasks/section_1/main.yml
+++ b/tasks/section_1/main.yml
@@ -1,54 +1,71 @@
 ---
 
 - name: "SECTION | 1.1.1.x | Disable unused filesystems"
-  ansible.builtin.import_tasks: cis_1.1.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.1.x.yml
 
 - name: "SECTION | 1.1.2.x | Configure /tmp"
-  ansible.builtin.import_tasks: cis_1.1.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.2.x.yml
 
 - name: "SECTION | 1.1.3.x | Configure /var"
-  ansible.builtin.import_tasks: cis_1.1.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.3.x.yml
 
 - name: "SECTION | 1.1.4.x | Configure /var/tmp"
-  ansible.builtin.import_tasks: cis_1.1.4.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.4.x.yml
 
 - name: "SECTION | 1.1.5.x | Configure /var/log"
-  ansible.builtin.import_tasks: cis_1.1.5.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.5.x.yml
 
 - name: "SECTION | 1.1.6.x | Configure /var/log/audit"
-  ansible.builtin.import_tasks: cis_1.1.6.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.6.x.yml
 
 - name: "SECTION | 1.1.7.x | Configure /home"
-  ansible.builtin.import_tasks: cis_1.1.7.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.7.x.yml
 
 - name: "SECTION | 1.1.8.x | Configure /dev/shm"
-  ansible.builtin.import_tasks: cis_1.1.8.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.8.x.yml
 
 - name: "SECTION | 1.1.9 | Disable various mounting"
-  ansible.builtin.import_tasks: cis_1.1.9.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.1.9.yml
 
 - name: "SECTION | 1.2 | Configure Software Updates"
-  ansible.builtin.import_tasks: cis_1.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.2.x.yml
 
 - name: "SECTION | 1.3 | Filesystem Integrity Checking"
-  ansible.builtin.import_tasks: cis_1.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.3.x.yml
   when: amzn2023cis_config_aide
 
 - name: "SECTION | 1.4 | Secure Boot Settings"
-  ansible.builtin.import_tasks: cis_1.4.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.4.x.yml
 
 - name: "SECTION | 1.5 | Additional Process Hardening"
-  ansible.builtin.import_tasks: cis_1.5.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.5.x.yml
 
 - name: "SECTION | 1.6 | Mandatory Access Control"
-  include_tasks: cis_1.6.1.x.yml
+  ansible.builtin.include_tasks:
+    file: cis_1.6.1.x.yml
   when: not amzn2023cis_selinux_disable
 
 - name: "SECTION | 1.7 | Command Line Warning Banners"
-  ansible.builtin.import_tasks: cis_1.7.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.7.x.yml
 
 - name: "SECTION | 1.8 | Updates and Patches"
-  ansible.builtin.import_tasks: cis_1.8.yml
+  ansible.builtin.import_tasks:
+    file: cis_1.8.yml
 
 - name: "SECTION | 1.9 | Crypto policies"
-  include_tasks: cis_1.9.yml
+  ansible.builtin.include_tasks:
+    file: cis_1.9.yml

--- a/tasks/section_2/cis_2.4.yml
+++ b/tasks/section_2/cis_2.4.yml
@@ -25,7 +25,8 @@
                 - "{{ amzn2023cis_2_4_sockets.stdout_lines }}"
 
       - name: "2.4 | AUDIT | Ensure nonessential services listening on the system are removed or masked | Warn Count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
   vars:
       warn_control_id: '2.4'
   when:

--- a/tasks/section_2/main.yml
+++ b/tasks/section_2/main.yml
@@ -1,13 +1,17 @@
 ---
 
 - name: "SECTION | 2.1 | Time Synchronization"
-  ansible.builtin.import_tasks: cis_2.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_2.1.x.yml
 
 - name: "SECTION | 2.2 | Special Purpose Services"
-  ansible.builtin.import_tasks: cis_2.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_2.2.x.yml
 
 - name: "SECTION | 2.3 | Service Clients"
-  ansible.builtin.import_tasks: cis_2.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_2.3.x.yml
 
 - name: "SECTION | 2.4 | Nonessential services removed"
-  ansible.builtin.import_tasks: cis_2.4.yml
+  ansible.builtin.import_tasks:
+    file: cis_2.4.yml

--- a/tasks/section_3/cis_3.4.2.x.yml
+++ b/tasks/section_3/cis_3.4.2.x.yml
@@ -47,7 +47,8 @@
             - not amzn2023cis_nft_tables_autonewtable
 
       - name: "3.4.2.2 | AUDIT | Ensure an nftables table exists | Alert on no tables | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when:
             - amzn2023cis_3_4_2_2_nft_tables.stdout | length == 0
             - not amzn2023cis_nft_tables_autonewtable

--- a/tasks/section_3/main.yml
+++ b/tasks/section_3/main.yml
@@ -1,16 +1,21 @@
 ---
 
 - name: "SECTION | 3.1.x | Disable unused network protocols and devices"
-  ansible.builtin.import_tasks: cis_3.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_3.1.x.yml
 
 - name: "SECTION | 3.2.x | Network Parameters (Host Only)"
-  ansible.builtin.import_tasks: cis_3.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_3.2.x.yml
 
 - name: "SECTION | 3.3.x | Network Parameters (host and Router)"
-  ansible.builtin.import_tasks: cis_3.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_3.3.x.yml
 
 - name: "SECTION | 3.4.1.x | Firewall configuration"
-  ansible.builtin.import_tasks: cis_3.4.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_3.4.1.x.yml
 
 - name: "SECTION | 3.4.2.x | Configure firewall"
-  ansible.builtin.import_tasks: cis_3.4.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_3.4.2.x.yml

--- a/tasks/section_4/cis_4.6.1.x.yml
+++ b/tasks/section_4/cis_4.6.1.x.yml
@@ -113,7 +113,8 @@
             - not amzn2023cis_futurepwchgdate_autofix
 
       - name: "4.6.1.5 | AUDIT | Ensure all users last password change date is in the past | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when:
             - amzn2023cis_4_6_1_5_user_list.stdout | length > 0
             - not amzn2023cis_futurepwchgdate_autofix

--- a/tasks/section_4/main.yml
+++ b/tasks/section_4/main.yml
@@ -3,24 +3,31 @@
 # Access, Authentication, and Authorization
 
 - name: "SECTION | 4.1 | Configure time-based job schedulers"
-  ansible.builtin.import_tasks: cis_4.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.1.x.yml
 
 - name: "SECTION | 4.2 | Configure SSH Server"
-  ansible.builtin.import_tasks: cis_4.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.2.x.yml
   when:
       - "'openssh-server' in ansible_facts.packages"
 
 - name: "SECTION | 4.3 | Configure privilege escalation"
-  ansible.builtin.import_tasks: cis_4.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.3.x.yml
 
 - name: "SECTION | 4.4 | Configure authselect"
-  ansible.builtin.import_tasks: cis_4.4.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.4.x.yml
 
 - name: "SECTION | 4.5 | Configure PAM "
-  ansible.builtin.import_tasks: cis_4.5.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.5.x.yml
 
 - name: "SECTION | 4.6.1.x | Shadow Password Suite Parameters"
-  ansible.builtin.import_tasks: cis_4.6.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.6.1.x.yml
 
 - name: "SECTION | 4.6.x | Misc. User Account Settings"
-  ansible.builtin.import_tasks: cis_4.6.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_4.6.x.yml

--- a/tasks/section_5/cis_5.1.2.x.yml
+++ b/tasks/section_5/cis_5.1.2.x.yml
@@ -98,7 +98,8 @@
         when: "'static' not in amzn2023cis_5_1_2_2_status.stdout"
 
       - name: "5.1.2.2 | AUDIT | Ensure journald service is enabled | Warn Count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when: "'static' not in amzn2023cis_5_1_2_2_status.stdout"
   vars:
       warn_control_id: '5.1.2.2'

--- a/tasks/section_5/cis_5.3.yml
+++ b/tasks/section_5/cis_5.3.yml
@@ -39,7 +39,8 @@
               loop: "{{ log_rotates.files }}"
 
             - name: "5.3 | AUDIT | Ensure logrotate is configured | Warning count"
-              ansible.builtin.import_tasks: warning_facts.yml
+              ansible.builtin.import_tasks:
+                file: warning_facts.yml
         vars:
             warn_control_id: '5.3'
         when: log_rotates.matched > 0

--- a/tasks/section_5/main.yml
+++ b/tasks/section_5/main.yml
@@ -3,32 +3,41 @@
 # Logging and Auditing
 
 - name: "SECTION | 5.1.1 | Configure Logging - rsyslog"
-  ansible.builtin.import_tasks: cis_5.1.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.1.1.x.yml
   when: amzn2023cis_syslog_service == 'rsyslog'
 
 - name: "SECTION | 5.1.2 | Configure Logging - journald"
-  ansible.builtin.import_tasks: cis_5.1.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.1.2.x.yml
   when: amzn2023cis_syslog_service == 'journald'
 
 - name: "SECTION | 5.1.3 | Configure logfile perms"
-  ansible.builtin.import_tasks: cis_5.1.3.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.1.3.yml
 
 - name: "SECTION | 5.2.1 | Configure System Accounting (auditd)"
-  ansible.builtin.import_tasks: cis_5.2.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.2.1.x.yml
   when:
       - not system_is_container
 
 - name: "SECTION | 5.2.2 | Configure Data Retention"
-  ansible.builtin.import_tasks: cis_5.2.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.2.2.x.yml
 
 - name: "SECTION | 5.2.3 | Configure Auditd rules"
-  ansible.builtin.import_tasks: cis_5.2.3.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.2.3.x.yml
 
 - name: "SECTION | 5.2.4 | Configure Audit files"
-  ansible.builtin.import_tasks: cis_5.2.4.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.2.4.x.yml
 
 - name: "SECTION | 5.3 | Configure LogRotate"
-  ansible.builtin.import_tasks: cis_5.3.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.3.yml
 
 - name: "SECTION | 5.3 | Configure logrotate"
-  ansible.builtin.import_tasks: cis_5.3.yml
+  ansible.builtin.import_tasks:
+    file: cis_5.3.yml

--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -153,7 +153,8 @@
                       The file list can be found in {{ amzn2023cis_rpm_audit_file }}"
 
             - name: "6.1.9 | AUDIT | Audit system file permissions | warning count"
-              ansible.builtin.import_tasks: warning_facts.yml
+              ansible.builtin.import_tasks:
+                file: warning_facts.yml
               vars:
                   warn_control_id: '6.1.9'
               when: amzn2023cis_6_1_9_packages_rpm.stdout|length > 0
@@ -258,7 +259,8 @@
         when: amzn2023cis_6_1_11_ungrouped_files_found
 
       - name: "6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | warning"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.1.11'
         when: amzn2023cis_6_1_11_unowned_files_found or amzn2023cis_6_1_11_ungrouped_files_found
@@ -340,7 +342,8 @@
         when: amzn2023cis_6_1_12_sgid_found
 
       - name: "6.1.12 | AUDIT | Ensure SUID and SGID files are reviewed | Alert SUID/SGID exist | warning"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.1.12'
         when: amzn2023cis_6_1_12_suid_found or amzn2023cis_6_1_12_sgid_found

--- a/tasks/section_6/cis_6.2.x.yml
+++ b/tasks/section_6/cis_6.2.x.yml
@@ -15,7 +15,8 @@
         when: shadow_passwd.stdout | length > 0
 
       - name: "6.2.1 | AUDIT | Ensure accounts in /etc/passwd use shadowed passwords | warning fact"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.2.1'
         when: shadow_passwd.stdout | length >= 1
@@ -58,7 +59,8 @@
         when: amzn2023cis_6_2_3_passwd_gid_check.stdout | length >= 1
 
       - name: "6.2.3 | AUDIT | Ensure all groups in /etc/passwd exist in /etc/group | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.2.3'
         when: amzn2023cis_6_2_3_passwd_gid_check.stdout | length >= 1
@@ -90,7 +92,8 @@
         when: amzn2023cis_6_2_4_user_uid_check.stdout | length >= 1
 
       - name: "6.2.4 | AUDIT| Ensure no duplicate UIDs exist | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         when: amzn2023cis_6_2_4_user_uid_check.stdout | length >= 1
   vars:
       warn_control_id: '6.2.4'
@@ -122,7 +125,8 @@
         when: amzn2023cis_6_2_5_user_user_check.stdout | length >= 1
 
       - name: "6.2.5 | AUDIT | Ensure no duplicate GIDs exist | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.2.5'
         when: amzn2023cis_6_2_5_user_user_check.stdout_lines | length >= 1
@@ -155,7 +159,8 @@
         when: amzn2023cis_6_2_6_user_username_check.stdout | length >= 1
 
       - name: "6.2.6 | AUDIT | Ensure no duplicate user names exist | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.2.6'
         when: amzn2023cis_6_2_6_user_username_check.stdout | length >= 1
@@ -188,7 +193,8 @@
         when: amzn2023cis_6_2_7_group_group_check.stdout is not defined
 
       - name: "6.2.7 | AUDIT | Ensure no duplicate group names exist | warning count"
-        ansible.builtin.import_tasks: warning_facts.yml
+        ansible.builtin.import_tasks:
+          file: warning_facts.yml
         vars:
             warn_control_id: '6.2.7'
         when: amzn2023cis_6_2_7_group_group_check.stdout is not defined

--- a/tasks/section_6/main.yml
+++ b/tasks/section_6/main.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "SECTION | 6.1 | System File Permissions"
-  ansible.builtin.import_tasks: cis_6.1.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_6.1.x.yml
 
 - name: "SECTION | 6.2 | User and Group Settings"
-  ansible.builtin.import_tasks: cis_6.2.x.yml
+  ansible.builtin.import_tasks:
+    file: cis_6.2.x.yml


### PR DESCRIPTION
**Overall Review of Changes:**
These changes will try to correct one error and multiple hints within Ansible tasks I have encountered when running some checks with [Steampunk Spotter](https://steampunk.si/spotter/). 

**Enhancements:**
The first change fixes the following error detected by the Spotter CLI:

```console
(.venv) user@ubuntu:~/UBUNTU22-CIS$ spotter scan --ansible-version 2.12 --display-level error .
Scanning...success. ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
------------------------------------------------------------------------
tasks/pre_remediation_audit.yml:60:9: ERROR: [E005] that is a required parameter in module ansible.builtin.assert.
------------------------------------------------------------------------
Spotter took 2.135 s to scan your input.
It resulted in 1 error(s), 27 warning(s) and 227 hint(s).
Overall status: ERROR
```

I also used Spotter's rewrite feature (`--rewrite`) to correct a bad practice of inline passing of parameters to modules and replaced that with exact parameters.

**How has this been tested?:**
N/A

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

