### PR TITLE
Update cis_4.6.x.yml

### DIFF
--- a/tasks/section_4/cis_4.6.x.yml
+++ b/tasks/section_4/cis_4.6.x.yml
@@ -92,7 +92,7 @@
       - name: "4.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Set umask for /etc/login.defs pam_umask settings"
         ansible.builtin.lineinfile:
             path: "{{ item.path }}"
-            regexp: '(?i)(umask\s*)'
+            regexp: '(?i)^\s*umask\s*'
             line: '{{ item.line }} 027'
         with_items:
             - { path: '/etc/bashrc', line: 'umask' }


### PR DESCRIPTION
Avoid capturing commented out lines.
Removed parenthesis as the capture group is not used, so those were not required.

**Overall Review of Changes:**
The regex captures lines that are commented out and ansible lineinfile only changes last occurence. Made the regex explicitely look for a line that is not commented out.

**Issue Fixes:**
Control 4.6.5 is failing because the line being updated in /etc/login.defs is
```
# If HOME_MODE is not set, the value of UMASK is used to create the mode.
```
instead of
```
UMASK 022
```

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Manually tested on a local instance.
```
TASK [AMAZON2023-CIS : 4.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Set umask for /etc/login.defs pam_umask settings] ***
changed: [10.0.0.240] => (item={'path': '/etc/bashrc', 'line': 'umask'})
changed: [10.0.0.240] => (item={'path': '/etc/profile', 'line': 'umask'})
changed: [10.0.0.240] => (item={'path': '/etc/login.defs', 'line': 'UMASK'})

TASK [AMAZON2023-CIS : 4.6.5 | PATCH | Ensure default user umask is 027 or more restrictive | Set umask for /etc/bashrc] ***
changed: [10.0.0.240]
```
And then, logging in on the instance:
```
$ cat /etc/login.defs | grep -i umask
# Default initial "umask" value used by login(1) on non-PAM enabled systems.
# Default "umask" value for pam_umask(8) on PAM enabled systems.
# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
UMASK 027
# If HOME_MODE is not set, the value of UMASK is used to create the mode.
```
Before the change:
```
$ cat /etc/login.defs | grep -i umask
# Default initial "umask" value used by login(1) on non-PAM enabled systems.
# Default "umask" value for pam_umask(8) on PAM enabled systems.
# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
UMASK		022
UMASK 027
```
