### PR TITLE
Removing prelim for installing authconfig, as it is not used.

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -213,27 +213,6 @@
       - rule_5.2.4.6
       - rule_5.2.4.7
 
-- name: "PRELIM | Install authconfig"
-  ansible.builtin.package:
-      name: authconfig
-      state: present
-  become: true
-  when:
-      - amzn2023cis_use_authconfig
-      - amzn2023cis_rule_5_3_1 or
-        amzn2023cis_rule_5_3_2 or
-        amzn2023cis_rule_5_3_3 or
-       '"authconfig" not in ansible_facts.packages or
-       "auditd-lib" not in ansible_facts.packages'
-  tags:
-      - level1-server
-      - level1-workstation
-      - rule_5.3.1 or
-        rule_5.3.2 or
-        rule_5.3.3
-      - authconfig
-      - auditd
-
 - name: "PRELIM | 4.3.3 | Find all sudoers files."
   ansible.builtin.shell: "find /etc/sudoers /etc/sudoers.d/ -type f ! -name '*~' ! -name '*.*'"
   changed_when: false


### PR DESCRIPTION
**Overall Review of Changes:**
This PR provides the solution for this [issue](https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/50).

**Issue Fixes:**

- https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/50

**Enhancements:**
None

**How has this been tested?:**
Locally.

