### PR TITLE
Removing double import of "cis_5.3.yml".

### DIFF
--- a/tasks/section_5/main.yml
+++ b/tasks/section_5/main.yml
@@ -37,7 +37,3 @@
 - name: "SECTION | 5.3 | Configure LogRotate"
   ansible.builtin.import_tasks:
       file: cis_5.3.yml
-
-- name: "SECTION | 5.3 | Configure logrotate"
-  ansible.builtin.import_tasks:
-      file: cis_5.3.yml


### PR DESCRIPTION
**Overall Review of Changes:**
This PR provides a solution for this [issue](https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/54)

**Issue Fixes:**
- https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/54

**Enhancements:**
None

**How has this been tested?:**
N/A

