### PR TITLE
Adding empty iterator in case `auditd_conf_files` register is empty o…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,8 +42,8 @@
 
 - name: Setup rules if container
   when:
-      - ansible_connection == 'docker' or
-        ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+      - ansible_connection == 'docker' or ( ansible_virtualization_type is defined and
+        ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"])
   block:
       - name: Discover and set container variable if required
         ansible.builtin.set_fact:

--- a/tasks/section_5/cis_5.2.4.x.yml
+++ b/tasks/section_5/cis_5.2.4.x.yml
@@ -64,7 +64,7 @@
   ansible.builtin.file:
       path: "{{ item.path }}"
       mode: '0640'
-  loop: "{{ auditd_conf_files.files }}"
+  loop: "{{ auditd_conf_files.files|default([]) }}"
   loop_control:
       label: "{{ item.path }}"
   when:


### PR DESCRIPTION
…r undefined.

**Overall Review of Changes:**
This PR hold the solution for this [issue](https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/59).

**Issue Fixes:**
- https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/59

**Enhancements:**
None

**How has this been tested?:**
Tested locally.

