### PR TITLE
Post-remediation task fix.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,7 +160,9 @@
       - run_audit
   ansible.builtin.import_tasks:
       file: post_remediation_audit.yml
-
+  tags:
+      - run_audit
+      
 - name: Show Audit Summary
   when:
       - run_audit


### PR DESCRIPTION
**Overall Review of Changes:**
Added tag to "run post_remediation audit" task within tasks/main.yml

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses
N/A
**Enhancements:**
Please list any enhancements/features that are not open issue tickets
Post remediation now works with "run_audit" tag instead of failing
**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A
Tested against a public EC2 instance running Amazon Linux 2023. All tasks now complete successfully when using "run_audit" tag.
