### PR TITLE
ability to supress the package logging facts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1234,3 +1234,7 @@ audit_run_script_environment:
     AUDIT_BIN: "{{ audit_bin }}"
     AUDIT_FILE: 'goss.yml'
     AUDIT_CONTENT_LOCATION: "{{ audit_out_dir }}"
+
+#### Logging Configuration Settings ####
+# Set to true in order to supress the various tasks from logging
+suppress_package_facts_logging: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1238,3 +1238,4 @@ audit_run_script_environment:
 #### Logging Configuration Settings ####
 # Set to true in order to supress the various tasks from logging
 suppress_package_facts_logging: false
+suppress_etc_passwd_logging: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,6 +82,7 @@
 - name: Gather the package facts
   ansible.builtin.package_facts:
       manager: auto
+  no_log: suppress_package_facts_logging
   tags:
       - always
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,7 +82,7 @@
 - name: Gather the package facts
   ansible.builtin.package_facts:
       manager: auto
-  no_log: suppress_package_facts_logging
+  no_log: "{{ suppress_package_facts_logging | default(false) }}"
   tags:
       - always
 

--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -9,7 +9,6 @@
         register: amzn2023cis_passwd_file_audit
         no_log: "{{ suppress_etc_passwd_logging | default(false) }}"
 
-
       - name: "PRELIM | 5.5.2 | 6.2.7 | 6.2.8 | 6.2.20 | Split passwd entries"
         ansible.builtin.set_fact:
             amzn2023cis_passwd: "{{ amzn2023cis_passwd_file_audit.stdout_lines | map('regex_replace', ld_passwd_regex, ld_passwd_yaml) | map('from_yaml') | list }}"

--- a/tasks/parse_etc_password.yml
+++ b/tasks/parse_etc_password.yml
@@ -7,10 +7,13 @@
         changed_when: false
         check_mode: false
         register: amzn2023cis_passwd_file_audit
+        no_log: "{{ suppress_etc_passwd_logging | default(false) }}"
+
 
       - name: "PRELIM | 5.5.2 | 6.2.7 | 6.2.8 | 6.2.20 | Split passwd entries"
         ansible.builtin.set_fact:
             amzn2023cis_passwd: "{{ amzn2023cis_passwd_file_audit.stdout_lines | map('regex_replace', ld_passwd_regex, ld_passwd_yaml) | map('from_yaml') | list }}"
+        no_log: "{{ suppress_etc_passwd_logging | default(false) }}"
         loop: "{{ amzn2023cis_passwd_file_audit.stdout_lines }}"
         vars:
             ld_passwd_regex: >-

--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -292,5 +292,6 @@
 - name: "PRELIM | Gather the package facts after prelim"
   ansible.builtin.package_facts:
       manager: auto
+  no_log: "{{ suppress_package_facts_logging | default(false) }}"
   tags:
       - always


### PR DESCRIPTION
**Overall Review of Changes:**
There are quite a few tasks that have very verbose logs.  It would be nice to have the option to suppress some of these task outputs

**Enhancements:**
Ability to toggle logging for some very verbose ansible tasks

**How has this been tested?:**
Running the playbook

