### PR TITLE
manage skipped result

### DIFF
--- a/tasks/section_6/cis_6.1.x.yml
+++ b/tasks/section_6/cis_6.1.x.yml
@@ -234,7 +234,7 @@
 
       - name: "6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | Displaying any unowned files or directories"
         ansible.builtin.debug:
-            msg: "Warning!! Missing owner on items in {{ amzn2023cis_6_1_11_audit.results | map(attribute='stdout_lines') | flatten }}"  # noqa jinja[invalid]
+            msg: "Warning!! Missing owner on items in {{ amzn2023cis_6_1_11_audit.results | map(attribute='stdout_lines', default=[]) | flatten }}"  # noqa jinja[invalid]
         when: amzn2023cis_6_1_11_unowned_files_found
 
       - name: "6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | Finding all ungrouped files or directories"
@@ -261,7 +261,7 @@
 
       - name: "6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | Displaying all ungrouped files or directories"
         ansible.builtin.debug:
-            msg: "Warning!! Missing group on items in {{ amzn2023cis_6_1_11_audit.results | map(attribute='stdout_lines') | flatten }}"  # noqa jinja[invalid]
+            msg: "Warning!! Missing group on items in {{ amzn2023cis_6_1_11_audit.results | map(attribute='stdout_lines', default=[]) | flatten }}"  # noqa jinja[invalid]
         when: amzn2023cis_6_1_11_ungrouped_files_found
 
       - name: "6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | warning"


### PR DESCRIPTION
**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

[6.1.11](https://github.com/ansible-lockdown/AMAZON2023-CIS/blob/devel/tasks/section_6/cis_6.1.x.yml#L219-L224) execute `shell` module looping on `mounts` then filtered using `when`.

if the item is filtered then the result do not contains the usual fields from `shell` instead it looks like 
```
(item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': "item['device'].startswith('/dev')", 'item': {'mount': '/tmp', 'device': '/tmp', 'fstype': 'tmpfs', 'options': 'rw,seclabel,nosuid,nodev,noexec,relatime', 'dump': 0, 'passno': 0, 'size_total': 4095590400, 'size_available': 4095381504, 'block_size': 4096, 'block_total': 999900, 'block_available': 999849, 'block_used': 51, 'inode_total': 999900, 'inode_available': 999877, 'inode_used': 23, 'uuid': 'N/A'}, 'ansible_loop_var': 'item'})
```

and the [next](https://github.com/ansible-lockdown/AMAZON2023-CIS/blob/devel/tasks/section_6/cis_6.1.x.yml#L235-L238) task will fail with :
```
    amazon-ebs.base_ami: fatal: [default]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'stdout_lines'\n\nThe error appears to be in '/Users/xxxx/.ansible/roles/MindPointGroup.amazon2023_cis/tasks/section_6/cis_6.1.x.yml': line 235, column 9, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n      - name: \"6.1.11 | AUDIT | Ensure no unowned or ungrouped files or directories exist | Displaying any unowned files or directories\"\n        ^ here\n"}
```

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

this was introduced in https://github.com/ansible-lockdown/AMAZON2023-CIS/pull/83

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

tested manually in a packer build
