### PR TITLE
bugfix: Fix name to be standard used by Amazon

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Amazon 2023 cis benchmark
+- name: Apply Amazon Linux 2023 CIS hardening
   hosts: all
   become: true
 


### PR DESCRIPTION
**Overall Review of Changes:**
I know it's just cosmetic but, apply standard naming to the playbook name to match what Amazon calls OS.



