### PR TITLE
Adding amzn2023cis_umask to let the user control the actual value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -980,6 +980,11 @@ amzn2023cis_shell_session_timeout:
     # CIS states that this value shall never exceed 900 or be equal to 0.
     timeout: 600
 
+## Control 4.6.5 Ensure default user umask is 027 or more restrictive
+# The following variable specifies the "umask" to set in the `/etc/bashrc` and `/etc/profile` and `/etc/login.defs`.
+# The value needs to be `027` or more restrictive to comply with CIS standards
+amzn2023cis_umask: '027'
+
 ##
 ## Section 5 Control Variables
 ##

--- a/tasks/section_4/cis_4.6.x.yml
+++ b/tasks/section_4/cis_4.6.x.yml
@@ -93,7 +93,7 @@
         ansible.builtin.replace:
             path: "{{ item }}"
             regexp: ^(?i)(\s*umask)\s+(?!\d*[2,7]7)\d{3,4}
-            replace: '\1 027'
+            replace: '\1 {{ amzn2023cis_umask }}'
         loop:
             - /etc/bashrc
             - /etc/profile


### PR DESCRIPTION
**Enhancements:**
Let the user control the actual value of umask used in the system

**How has this been tested?:**
Executed the playbook and checked the files were properly modified.

