### PR TITLE
Add missing audispd and add selinux to all of the attributes

### DIFF
--- a/tasks/section_1/cis_1.3.x.yml
+++ b/tasks/section_1/cis_1.3.x.yml
@@ -58,12 +58,13 @@
       path: /etc/aide.conf
       marker: "# {mark} Audit tools - CIS benchmark - Ansible-lockdown"
       block: |
-        /sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
-        /sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
-        /sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
-        /sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
-        /sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
-        /sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
+        /sbin/auditctl p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/auditd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/augenrules p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/aureport p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/ausearch p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/autrace p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
+        /sbin/audispd p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
       validate: aide -D --config %s
   when:
       - amzn2023cis_rule_1_3_3


### PR DESCRIPTION
Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
The CIS Benchmark 1.3.3 doesn't have this but the SSG does. I believe the Benchmark is missing the audispd line and all of them are missing the selinux attribute.

**Issue Fixes:**
I did not create an issue but I can if necessary.

**Enhancements:**
The SSG correctly looks for audispd but this repo is not

**How has this been tested?:**
I use the AWS base EKS AMI, ran this hardening against it then ran the oscap ssg-al2023-ds.xml audit and it failed the check for audispd.

I also believe that because SELinux is required for CIS Level 1 and 2, it should appear in the aide.conf 
