### PR TITLE
fix: rsyslog validate fails with invalid `emrg` property name

### DIFF
--- a/tasks/section_5/cis_5.1.1.x.yml
+++ b/tasks/section_5/cis_5.1.1.x.yml
@@ -143,7 +143,7 @@
               local2,local3.*                                          -/var/log/localmessages
               local4,local5.*                                          -/var/log/localmessages
               local6,local7.*                                          -/var/log/localmessages
-              *.emrg                                                    :omusrmsg:*
+              *.emerg                                                    :omusrmsg:*
             insertafter: '#### RULES ####'
         notify: Restart rsyslog
 


### PR DESCRIPTION
**Overall Review of Changes:**
After applying CIS remediations, running rsyslog validation, the config file fails:

```
$ sudo rsyslogd -N 1 -f /etc/rsyslog.conf
rsyslogd: version 8.2204.0-3.amzn2023.0.4, config validation run (level 1), master config /etc/rsyslog.conf
rsyslogd: unknown priority name "emrg" [v8.2204.0-3.amzn2023.0.4]
```

It seems that maybe this is a typo and should be `emerg`:
```
$ sudo cat /etc/rsyslog.conf | grep em*rg
*.emrg                                                    :omusrmsg:*
# Everybody gets emergency messages
*.emerg                                                 :omusrmsg:*
```

[rsyslogd documentation](https://www.rsyslog.com/doc/configuration/filters.html) also specifies `emerg` and nothing for `emrg` from what can be found.

**Issue Fixes:**

**Enhancements:**

**How has this been tested?:**
N/A
