### PR TITLE
Align with the CIS benchmark for 4.6.6. Signed-off-by: Joan Doe  <joa…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
     - rule_4.6.6
   block:
     - name: Ensure root password is set
-      ansible.builtin.shell: passwd -S root | grep "Password set, SHA512 crypt"
+      ansible.builtin.shell: passwd -S root | grep "Password set"
       changed_when: false
       register: discovered_root_passwd_set
 


### PR DESCRIPTION
…n.doe@email.com>

Align with the CIS benchmark for 4.6.6 were the root password must be set but it does not need to be SHA512

Please ensure that you have understood contributing guide
Ensure all commits are signed-by and gpg signed

**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

**Issue Fixes:**
https://github.com/ansible-lockdown/AMAZON2023-CIS/issues/172

**Enhancements:**
N/A

**How has this been tested?:**
It was tested locally using the default YESCRYPT encryption on AL2023.
