### PR TITLE
Fix default umask

### DIFF
--- a/tasks/section_4/cis_4.6.x.yml
+++ b/tasks/section_4/cis_4.6.x.yml
@@ -98,7 +98,7 @@
       ansible.builtin.replace:
         path: '{{ item.path }}'
         regexp: (?i)(umask\s+\d*)
-        replace: '{{ item.line }} 027'
+        replace: '{{ item.line }}'
       loop:
         - {path: /etc/bashrc, line: 'umask {{ amzn2023cis_umask }}'}
         - {path: /etc/profile, line: 'umask {{ amzn2023cis_umask }}'}


### PR DESCRIPTION
**Overall Review of Changes:**
The umask replace task was appending a hardcoded  027 after `{{ item.line }}`, overriding the `amzn2023cis_umask` variable. Essentially 027 was both a hardcoded constant *and* the default value of `amzn2023cis_umask`. This drops the hardcoded value so the configured umask is used.

**Issue Fixes:**
Fixes #177

**How has this been tested?:**
N/A

